### PR TITLE
Add CSP enforcement and tidy guide assets

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -169,6 +169,17 @@ footer {
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
+.guide-section {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.guide-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
 .card {
   background: var(--card-bg);
   border-radius: 24px;

--- a/assets/js/guide.js
+++ b/assets/js/guide.js
@@ -1,0 +1,19 @@
+(function () {
+  const buttons = document.querySelectorAll('button[data-read]');
+
+  function speak(text) {
+    if (!('speechSynthesis' in window)) {
+      alert('此裝置不支援語音朗讀，請改以文字閱讀');
+      return;
+    }
+
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = 'zh-TW';
+    speechSynthesis.cancel();
+    speechSynthesis.speak(utterance);
+  }
+
+  buttons.forEach((button) => {
+    button.addEventListener('click', () => speak(button.getAttribute('data-read')));
+  });
+})();

--- a/forum.html
+++ b/forum.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' http://localhost:3001; img-src 'self' data:; style-src 'self'; font-src 'self'; script-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'">
   <title>社群公園｜智護生活</title>
   <link rel="stylesheet" href="assets/css/style.css">
 </head>

--- a/guide.html
+++ b/guide.html
@@ -3,19 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' http://localhost:3001; img-src 'self' data:; style-src 'self'; font-src 'self'; script-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'">
   <title>離線幫助指南｜智護生活</title>
   <link rel="stylesheet" href="assets/css/style.css">
-  <style>
-    .guide-section {
-      display: grid;
-      gap: 1.25rem;
-    }
-    .guide-actions {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.75rem;
-    }
-  </style>
+  <script src="assets/js/guide.js" defer></script>
 </head>
 <body>
   <div class="app-shell">
@@ -95,23 +86,5 @@
       <p>© 2024 智護生活團隊</p>
     </footer>
   </div>
-  <script>
-    (function() {
-      const buttons = document.querySelectorAll('button[data-read]');
-      function speak(text) {
-        if (!('speechSynthesis' in window)) {
-          alert('此裝置不支援語音朗讀，請改以文字閱讀');
-          return;
-        }
-        const utterance = new SpeechSynthesisUtterance(text);
-        utterance.lang = 'zh-TW';
-        speechSynthesis.cancel();
-        speechSynthesis.speak(utterance);
-      }
-      buttons.forEach(btn => {
-        btn.addEventListener('click', () => speak(btn.getAttribute('data-read')));
-      });
-    })();
-  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' http://localhost:3001; img-src 'self' data:; style-src 'self'; font-src 'self'; script-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'">
   <title>智護生活：AI 伴你</title>
   <link rel="stylesheet" href="assets/css/style.css">
 </head>

--- a/login.html
+++ b/login.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' http://localhost:3001; img-src 'self' data:; style-src 'self'; font-src 'self'; script-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'">
   <title>登入｜智護生活</title>
   <link rel="stylesheet" href="assets/css/style.css">
 </head>

--- a/ranking.html
+++ b/ranking.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' http://localhost:3001; img-src 'self' data:; style-src 'self'; font-src 'self'; script-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'">
   <title>健康排行榜｜智護生活</title>
   <link rel="stylesheet" href="assets/css/style.css">
 </head>

--- a/registration.html
+++ b/registration.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' http://localhost:3001; img-src 'self' data:; style-src 'self'; font-src 'self'; script-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'">
   <title>註冊｜智護生活</title>
   <link rel="stylesheet" href="assets/css/style.css">
 </head>

--- a/selection.html
+++ b/selection.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' http://localhost:3001; img-src 'self' data:; style-src 'self'; font-src 'self'; script-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'">
   <title>選擇陪伴年齡｜智護生活</title>
   <link rel="stylesheet" href="assets/css/style.css">
 </head>

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -22,6 +22,10 @@ app.use('/api/chat', chatRouter)
 app.use('/api/ranking', rankingRouter)
 app.use('/api/geofence', geofenceRouter)
 
+app.get('/.well-known/appspecific/com.chrome.devtools.json', (req, res) => {
+  res.json({ default_locale: 'en-US' })
+})
+
 app.use((err, req, res, next) => {
   console.error(err)
   res.status(err.status || 500).json({

--- a/setting.html
+++ b/setting.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' http://localhost:3001; img-src 'self' data:; style-src 'self'; font-src 'self'; script-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'">
   <title>快速設定｜智護生活</title>
   <link rel="stylesheet" href="assets/css/style.css">
 </head>


### PR DESCRIPTION
## Summary
- add a shared Content Security Policy meta tag to every static page so API calls to the backend are allowed while keeping other origins blocked
- move the guide page's inline styles and script into dedicated CSS/JS assets to comply with the stricter CSP
- provide a stub `.well-known` endpoint in the backend to eliminate noisy 404s triggered by DevTools probes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4a3df957c8327851f946d8185e9e5